### PR TITLE
Update elgentos/parser (2.4.0 => 2.6.1)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,11 @@
   "require": {
     "php": "^7.1.3",
     "doctrine/dbal": "~2.3",
+    "elgentos/parser": "~2.5",
     "fzaninotto/faker": "^1.7",
-    "symfony/console": "^4.1",
     "illuminate/database": "^5.6",
-    "symfony/yaml": "^4.1",
-    "elgentos/parser": "~2.3"
+    "symfony/console": "^4.1",
+    "symfony/yaml": "^4.1"
   },
   "license": "MIT",
   "authors": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2daac11b590bbc5a2bbdfc2f118c868e",
+    "content-hash": "9a162ae6fa2f5fd13f664756b804dae9",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -486,20 +486,20 @@
         },
         {
             "name": "elgentos/parser",
-            "version": "2.4.0",
+            "version": "2.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/elgentos/parser.git",
-                "reference": "ff55d6bac500409e580f773a9acc1b713f8401d8"
+                "reference": "e7bb6ec6a75856544a3daab6e8bc5aa48eccff27"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elgentos/parser/zipball/ff55d6bac500409e580f773a9acc1b713f8401d8",
-                "reference": "ff55d6bac500409e580f773a9acc1b713f8401d8",
+                "url": "https://api.github.com/repos/elgentos/parser/zipball/e7bb6ec6a75856544a3daab6e8bc5aa48eccff27",
+                "reference": "e7bb6ec6a75856544a3daab6e8bc5aa48eccff27",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0"
+                "php": ">=7.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^6.0",
@@ -529,7 +529,7 @@
             ],
             "description": "Elgentos Parser for json/yaml files to readable array",
             "homepage": "https://elgentos.nl/",
-            "time": "2018-11-28T16:39:19+00:00"
+            "time": "2019-05-02T15:48:29+00:00"
         },
         {
             "name": "fzaninotto/faker",


### PR DESCRIPTION
There are dependencies on class `Elgentos\Parser\Stories\Reader\Complex`, which was introduced in `elgentos/parser:2.5.0`. 

I changed the constraint and updated the lock. My composer also automatically sorted the composer.json, let me know if you don't want that :).