### PR TITLE
Update readme with link that will always point to latest phar

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ customer:
 Download the phar file:
 
 ```
-wget https://github.com/elgentos/masquerade/releases/download/{VERSION}/masquerade.phar
+wget https://github.com/elgentos/masquerade/releases/latest/download/masquerade.phar
 ```
 
 ### Usage


### PR DESCRIPTION
This link format is documented here: https://help.github.com/en/articles/linking-to-releases#linking-to-the-latest-release