### PR TITLE
Update installation command to be more broadly supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ customer:
 Download the phar file:
 
 ```
-wget https://github.com/elgentos/masquerade/releases/latest/download/masquerade.phar
+curl -L -o masquerade.phar https://github.com/elgentos/masquerade/releases/latest/download/masquerade.phar
 ```
 
 ### Usage


### PR DESCRIPTION
Many systems don't come with `wget` preinstalled. `curl` is more ubiquitous. 

Many people are familiar with using `curl` and I wouldn't have bothered with submitting this PR as they could just use `curl` if their system didn't have `wget`. However when I ran this command (without the `-L` flag)…

```
curl -o masquerade.phar https://github.com/elgentos/masquerade/releases/latest/download/masquerade.phar
```

…the downloaded file contained this content:

```
<html><body>You are being <a href="https://github.com/elgentos/masquerade/releases/download/0.1.10/masquerade.phar">redirected</a>.</body></html>
```

I had to add the `-L` flag for Curl to follow the redirect.

Since I was the one who submitted a PR to change the url to a url that included a redirect, I felt it my responsibility to update this documentation to a command that will work everywhere and won't require `curl` users looking up the `-L` flag. :) 

I tested this updated command on macOS and CentOS 7.