### PR TITLE
Add readme making it obvious that M1 is not supported

### DIFF
--- a/src/config/magento1/README.md
+++ b/src/config/magento1/README.md
@@ -1,0 +1,3 @@
+# Magento 1 Support
+
+Magento 1 is not currently supported. Feel free to submit a PR to finish configuring these files.


### PR DESCRIPTION
I realize your readme said that only M2 was supported, but I noticed the configuration files in `src/config/magento1/`, so I decided to take a stab at running masquerade against an M1 site.

I was hopeful until I saw the error below and realized the [`customer.yml` file](https://github.com/erikhansen/masquerade/blob/master/src/config/magento1/customer.yaml) file was empty, thus why you didn't declare support. I would offer to add M1 support, but in the interest of time, I'll probably be using [one of the options](https://github.com/aleron75/mageres#free) that already supports M1. Feel free to reject my PR and add a note to the main readme instead.

![html 2019-10-24 17-08-37](https://user-images.githubusercontent.com/129031/67529154-f77e3100-f680-11e9-8859-9de06f6a46f4.jpg)
