### PR TITLE
Fix error 'Data truncated for column remote_ip_long'

### DIFF
--- a/src/config/magento2/rating.yaml
+++ b/src/config/magento2/rating.yaml
@@ -5,4 +5,6 @@ rating:
       remote_ip:
         formatter: ipv4
       remote_ip_long:
-        formatter: ipv6
+        formatter: 
+          name: randomNumber
+          nbDigits: 10

--- a/src/config/magento2/rating.yaml
+++ b/src/config/magento2/rating.yaml
@@ -5,6 +5,4 @@ rating:
       remote_ip:
         formatter: ipv4
       remote_ip_long:
-        formatter: 
-          name: randomNumber
-          nbDigits: 10
+        formatter: randomNumber


### PR DESCRIPTION
I get the following error when running Masquerade:
```
Updating rating_option_vote
 18234/18234 [============================] 100%     0/13690 [>---------------------------]   0%
In Connection.php line 664:
                                                                               
  SQLSTATE[01000]: Warning: 1265 Data truncated for column 'remote_ip_long' a  
  t row 1 (SQL: update `rating_option_vote` set `remote_ip` = 123.246.255.24,   
  `remote_ip_long` = 8fd6:6847:40b1:4945:d34c:d295:b461:46c6 where `vote_id`   
  = 1)                                                                         
                                                                               
In PDOStatement.php line 119:
                                                                               
  SQLSTATE[01000]: Warning: 1265 Data truncated for column 'remote_ip_long' a  
  t row 1                                                                      
                                                                               

In PDOStatement.php line 117:
                                                                               
  SQLSTATE[01000]: Warning: 1265 Data truncated for column 'remote_ip_long' a  
  t row 1                              
```

If I look at the source DB it seems that `rating_option_vote.remote_ip_long` is just a random number, not an ipv6 address. 

Also check the file vendor/magento/module-review/etc/db_schema.xml:
```xml
...
    <table name="rating_option_vote" resource="default" engine="innodb" comment="Rating option values">
        <column xsi:type="bigint" name="remote_ip_long" padding="20" unsigned="false" nullable="false" identity="false"
                default="0" comment="Customer IP converted to long integer format"/>
    </table>
...
```
Which shows the Bigint column type.

