### PR TITLE
Allow EAV and other extended table types

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@ For example, to override the `admin.yaml` for Magento 2, you place a file in `co
 admin:
 ```
 
+You can also truncate, partially delete, or partially anonymize tables - for example, anonymize customer data except for specific records which you use for unit testing, or truncate tables which are just access logs.
+
 For formatters, you can use all default [Faker formatters](https://github.com/fzaninotto/Faker#formatters).
 
-#### Custom Providers / Formatters
+#### Custom Data Providers / Formatters
 
 You can also create your own custom providers with formatters. They need to extend `Faker\Provider\Base` and they need to live in either `~/.masquerade` or `.masquerade` relative from where you run masquerade.
 
@@ -61,6 +63,46 @@ customer:
         provider: \Custom\WoopFormatter
         formatter:
           name: woopwoop
+```
+
+### Custom Table Type Providers
+
+Some systems have linked tables containing related data - eg. Magento's EAV system, Drupal's entity fields and Wordpress's post metadata tables.  You can provide custom table types like this:
+
+An example file `.masquerade/Custom/WoopTable.php`;
+
+```php
+<?php
+
+namespace Custom;
+
+use Elgentos\Masquerade\Provider\Table\Base;
+
+class WoopTable extends Base {
+
+    public function setup() // do any one-off work - eg. delete/truncate, find EAV attributes, create temporary tables
+
+    public function columns() // return a list of the column names that will be faked - these don't have to be real database fields
+
+    public function update($primaryKey, [field=>value, ...]) // update a record - handle the update of any special field types here
+
+    public function query() // return an Illuminate database query object giving all the records you want to affect, and selecting all the columns
+}
+```
+
+And then use it in your YAML file. A provider needs to be set on the table level, and can be a simple class name, or a set of options which are available to your class.  See the documentation in the 'Base' class, and the code for the 'Simple' table type for more details.
+
+```
+customer:
+  customer_entity:
+    provider:
+      class: \Custom\WoopTable
+      option1: "test"
+      option2: false
+    columns:
+      firstname:
+        formatter:
+          name: firstName
 ```
 
 ### Installation

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ class WoopTable extends Base {
 
     public function columns() // return a list of the column names that will be faked - these don't have to be real database fields
 
+    public function getPrimaryKey() // if you inherit \Elgentos\Masquerade\Provider\Table\Simple, this will be guessed
+
     public function update($primaryKey, [field=>value, ...]) // update a record - handle the update of any special field types here
 
     public function query() // return an Illuminate database query object giving all the records you want to affect, and selecting all the columns

--- a/src/Elgentos/Masquerade/Console/RunCommand.php
+++ b/src/Elgentos/Masquerade/Console/RunCommand.php
@@ -22,6 +22,8 @@ class RunCommand extends Command
 
     const VERSION = '0.1.9';
 
+    const DEFAULT_QUERY_PROVIDER = \Elgentos\Masquerade\Provider\Table\Simple::class;
+
     protected $config;
 
     /**
@@ -121,39 +123,30 @@ class RunCommand extends Command
      */
     private function fakeData(array $table) : void
     {
-        if (!$this->db->getSchemaBuilder()->hasTable($table['name'])) {
-            $this->output->writeln('Table ' . $table['name'] . ' does not exist.');
-            return;
+        $tableProviderData = array_get($table, 'provider', self::DEFAULT_QUERY_PROVIDER);
+        $tableProviderClass = array_get($table, 'provider.class', null);
+        if (!$tableProviderClass) {
+            $tableProviderClass = $tableProviderData;
+            $tableProviderData = ['class' => $tableProviderClass];
         }
-
-        foreach ($table['columns'] as $columnName => $columnData) {
-            if (!$this->db->getSchemaBuilder()->hasColumn($table['name'], $columnName)) {
-                unset($table['columns'][$columnName]);
-                $this->output->writeln('Column ' . $columnName . ' in table ' . $table['name'] . ' does not exist; skip it.');
-            }
-        }
+        $tableProvider = new $tableProviderClass($this->db, $tableProviderData, $table);
 
         $this->output->writeln('');
         $this->output->writeln('Updating ' . $table['name']);
 
-        $totalRows = $this->db->table($table['name'])->count();
+        $tableProvider->setup();
+
+        $totalRows = $tableProvider->query()->count();
         $progressBar = new ProgressBar($this->output, $totalRows);
         $progressBar->setRedrawFrequency($this->calculateRedrawFrequency($totalRows));
         $progressBar->start();
 
         $primaryKey = array_get($table, 'pk', 'entity_id');
 
-        // Null columns before run to avoid integrity constrains errors
-        foreach ($table['columns'] as $columnName => $columnData) {
-            if (array_get($columnData, 'nullColumnBeforeRun', false)) {
-                $this->db->table($table['name'])->update([$columnName => null]);
-            }
-        }
-
-        $this->db->table($table['name'])->orderBy($primaryKey)->chunk(100, function ($rows) use ($table, $progressBar, $primaryKey) {
+        $tableProvider->query()->chunk(100, function ($rows) use ($table, $progressBar, $primaryKey) {
             foreach ($rows as $row) {
                 $updates = [];
-                foreach ($table['columns'] as $columnName => $columnData) {
+                foreach ($tableProvider->columns() as $columnName => $columnData) {
                     $formatter = array_get($columnData, 'formatter.name');
                     $formatterData = array_get($columnData, 'formatter');
                     $providerClassName = array_get($columnData, 'provider', false);
@@ -188,7 +181,7 @@ class RunCommand extends Command
                         $updates[$columnName] = null;
                     }
                 }
-                $this->db->table($table['name'])->where($primaryKey, $row->{$primaryKey})->update($updates);
+                $tableProvider->update($row->{$primaryKey}, $updates);
                 $progressBar->advance();
             }
         });

--- a/src/Elgentos/Masquerade/Console/RunCommand.php
+++ b/src/Elgentos/Masquerade/Console/RunCommand.php
@@ -11,6 +11,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Faker\Factory as FakerFactory;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Illuminate\Database\Capsule\Manager as Capsule;
+use Illuminate\Support\Arr;
 
 class RunCommand extends Command
 {

--- a/src/Elgentos/Masquerade/Console/RunCommand.php
+++ b/src/Elgentos/Masquerade/Console/RunCommand.php
@@ -135,7 +135,7 @@ class RunCommand extends Command
 
         $tableProvider->setup();
 
-        $totalRows = $tableProvider->query()->count();
+        $totalRows = $tableProvider->count();
         $progressBar = new ProgressBar($this->output, $totalRows);
         $progressBar->setRedrawFrequency($this->calculateRedrawFrequency($totalRows));
         $progressBar->start();

--- a/src/Elgentos/Masquerade/Console/RunCommand.php
+++ b/src/Elgentos/Masquerade/Console/RunCommand.php
@@ -246,7 +246,7 @@ class RunCommand extends Command
         ]);
 
         $this->db = $capsule->getConnection();
-        if(!$this->input->getOption('with-integrity')) {
+        if (!$this->input->getOption('with-integrity')) {
             $this->output->writeln('[Foreign key constraint checking is off - deletions will not affect linked tables]');
             $this->db->statement('SET FOREIGN_KEY_CHECKS=0');
         }

--- a/src/Elgentos/Masquerade/Console/RunCommand.php
+++ b/src/Elgentos/Masquerade/Console/RunCommand.php
@@ -123,16 +123,15 @@ class RunCommand extends Command
      */
     private function fakeData(array $table) : void
     {
-        $tableProviderData = array_get($table, 'provider', self::DEFAULT_QUERY_PROVIDER);
-        $tableProviderClass = array_get($table, 'provider.class', null);
-        if (!$tableProviderClass) {
-            $tableProviderClass = $tableProviderData;
-            $tableProviderData = ['class' => $tableProviderClass];
+        $tableProviderData = array_get($table, 'provider', []);
+        if (is_string($tableProviderData)) {
+            $tableProviderData = ['class' => $tableProviderData]; // just a class rather than array of options
         }
+        $tableProviderClass = array_get($tableProviderData, 'class', self::DEFAULT_QUERY_PROVIDER);
         $tableProvider = new $tableProviderClass($this->output, $this->db, $table, $tableProviderData);
 
         $this->output->writeln('');
-        $this->output->writeln('Updating ' . $table['name']);
+        $this->output->writeln('Updating ' . $table['name'] . ' using '. $tableProviderClass);
 
         $tableProvider->setup();
 

--- a/src/Elgentos/Masquerade/Console/RunCommand.php
+++ b/src/Elgentos/Masquerade/Console/RunCommand.php
@@ -140,7 +140,7 @@ class RunCommand extends Command
         $progressBar->setRedrawFrequency($this->calculateRedrawFrequency($totalRows));
         $progressBar->start();
 
-        $primaryKey = array_get($table, 'pk', 'entity_id');
+        $primaryKey = $tableProvider->getPrimaryKey();
 
         $tableProvider->query()->chunk(100, function ($rows) use ($table, $progressBar, $primaryKey, $tableProvider) {
             foreach ($rows as $row) {

--- a/src/Elgentos/Masquerade/Console/RunCommand.php
+++ b/src/Elgentos/Masquerade/Console/RunCommand.php
@@ -129,7 +129,7 @@ class RunCommand extends Command
             $tableProviderClass = $tableProviderData;
             $tableProviderData = ['class' => $tableProviderClass];
         }
-        $tableProvider = new $tableProviderClass($this->db, $tableProviderData, $table);
+        $tableProvider = new $tableProviderClass($this->output, $this->db, $table, $tableProviderData);
 
         $this->output->writeln('');
         $this->output->writeln('Updating ' . $table['name']);
@@ -143,7 +143,7 @@ class RunCommand extends Command
 
         $primaryKey = array_get($table, 'pk', 'entity_id');
 
-        $tableProvider->query()->chunk(100, function ($rows) use ($table, $progressBar, $primaryKey) {
+        $tableProvider->query()->chunk(100, function ($rows) use ($table, $progressBar, $primaryKey, $tableProvider) {
             foreach ($rows as $row) {
                 $updates = [];
                 foreach ($tableProvider->columns() as $columnName => $columnData) {

--- a/src/Elgentos/Masquerade/Provider/Table/Base.php
+++ b/src/Elgentos/Masquerade/Provider/Table/Base.php
@@ -73,6 +73,11 @@ abstract class Base
     }
 
     /**
+     * @return int The number of rows which will be affected
+     */
+    abstract public function count();
+
+    /**
      * Update a set of columns for a specific primary key
      * @param string|int Primary Key
      * @param array in the form [column_name => value, ...]

--- a/src/Elgentos/Masquerade/Provider/Table/Base.php
+++ b/src/Elgentos/Masquerade/Provider/Table/Base.php
@@ -58,6 +58,12 @@ abstract class Base
     }
 
     /**
+     * Return the name of the primary key column in the query returned by ->query()
+     * @return string
+     */
+    abstract public function getPrimaryKey();
+
+    /**
      * Return the columns with their config
      * @return array
      */

--- a/src/Elgentos/Masquerade/Provider/Table/Base.php
+++ b/src/Elgentos/Masquerade/Provider/Table/Base.php
@@ -32,8 +32,8 @@ use \Symfony\Component\Console\Output\OutputInterface;
  *
  */
 
-abstract class Base {
-
+abstract class Base
+{
     protected $output;
     protected $db;
     protected $table;

--- a/src/Elgentos/Masquerade/Provider/Table/Base.php
+++ b/src/Elgentos/Masquerade/Provider/Table/Base.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace \Elgentos\Masquerade\Provider\Table;
+
+use \Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * All table providers must inherit this
+ *
+ * example config:
+ *
+ * group1:   # the group
+ *   table1:  # the entity name
+ *     provider: \Elgentos\Masquerade\Provider\Table\YourProviderClass
+ *     columns:
+ *       cost_price:
+ *         ...your usual column formatting goes here...
+ *
+ * OR, if your provider takes options:
+ *
+ * group1:
+ *   table1:
+ *     provider:
+ *       class: \My\Custom\Class\Name
+ *       option1: "some value"
+ *       option2: "some value"
+ *
+ * In your class, the provider options will be accessible as $this->options['option1'] etc, and table data as $this->table[...]
+ *
+ * The setup() method will be called before any processing.
+ *
+ *
+ */
+
+abstract class Base {
+
+    protected OutputInterface $output;
+    protected \Illuminate\Database\Connection $db;
+    protected array $table;
+    protected array $options = [];
+
+    public function __construct(OutputInterface $output, \Illuminate\Database\Connection $db, array $tableData, array $providerData = [])
+    {
+        $this->output = $output;
+        $this->db = $db;
+        $this->table = $tableData;
+        $this->options = $providerData;
+    }
+
+    /**
+     * Do any setup or validation work here, eg. extracting details from the database for later use,
+     * removing unused columns, etc
+     *
+     * @return void
+     */
+    public function setup()
+    {
+    }
+
+    /**
+     * Return the columns with their config
+     * @return array
+     */
+    public function columns()
+    {
+        return $this->table['columns'];
+    }
+
+    /**
+     * Update a set of columns for a specific primary key
+     * @param string|int Primary Key
+     * @param array in the form [column_name => value, ...]
+     * @return void
+     */
+    abstract public function update($primaryKey, array $updates);
+
+    /**
+     * Return a query builder which will return the column names returned by $this->columns()
+     * It should be ordered by primary key
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
+    abstract public function query() : \Illuminate\Database\Query\Builder;
+}

--- a/src/Elgentos/Masquerade/Provider/Table/Base.php
+++ b/src/Elgentos/Masquerade/Provider/Table/Base.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace \Elgentos\Masquerade\Provider\Table;
+namespace Elgentos\Masquerade\Provider\Table;
 
 use \Symfony\Component\Console\Output\OutputInterface;
 
@@ -34,10 +34,10 @@ use \Symfony\Component\Console\Output\OutputInterface;
 
 abstract class Base {
 
-    protected OutputInterface $output;
-    protected \Illuminate\Database\Connection $db;
-    protected array $table;
-    protected array $options = [];
+    protected $output;
+    protected $db;
+    protected $table;
+    protected $options = [];
 
     public function __construct(OutputInterface $output, \Illuminate\Database\Connection $db, array $tableData, array $providerData = [])
     {

--- a/src/Elgentos/Masquerade/Provider/Table/Base.php
+++ b/src/Elgentos/Masquerade/Provider/Table/Base.php
@@ -2,7 +2,8 @@
 
 namespace Elgentos\Masquerade\Provider\Table;
 
-use \Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputInterface;
 
 /**
  * All table providers must inherit this
@@ -35,13 +36,15 @@ use \Symfony\Component\Console\Output\OutputInterface;
 abstract class Base
 {
     protected $output;
+    protected $input;
     protected $db;
     protected $table;
     protected $options = [];
 
-    public function __construct(OutputInterface $output, \Illuminate\Database\Connection $db, array $tableData, array $providerData = [])
+    public function __construct(InputInterface $input, OutputInterface $output, \Illuminate\Database\Connection $db, array $tableData, array $providerData = [])
     {
         $this->output = $output;
+        $this->input = $input;
         $this->db = $db;
         $this->table = $tableData;
         $this->options = $providerData;

--- a/src/Elgentos/Masquerade/Provider/Table/Magento2Eav.php
+++ b/src/Elgentos/Masquerade/Provider/Table/Magento2Eav.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace \Elgentos\Masquerade\Provider\Table;
+
+/**
+ * Allows column names to be EAV attributes. No options are required.
+ *
+ * The table name should be the base table for the entity - eg. catalog_product_entity
+ *
+ */
+
+class Magento2Eav extends Simple {
+
+    /**
+     * @var array of eav_attribute records
+     */
+    protected array $attributes = [];
+
+    protected stdClass $entity;
+
+    public function setup()
+    {
+        if (array_get($this->options, 'delete', false)) {
+            if (array_get($this->options, 'where', null)) {
+                $this->query()->delete(); // if it's an EAV table, this should cascade
+            } else {
+                $this->query()->truncate();
+            }
+        }
+
+        // check the table exists:
+            if (!$this->db->getSchemaBuilder()->hasTable($table['name'])) {
+            throw new \Exception('Table ' . $table['name'] . ' does not exist.');
+            }
+
+        // find all EAV attribues for this table:
+        $this->entity = $this->db->table('eav_entity_types')->where('entity_table', $this->table['name'])->first();
+        if (!$this->entity) {
+            throw new \Exception("Table {$this->table['name']} is not associated with EAV entities");
+        }
+        $attributes = $this->db->table('eav_attribute')->where('entity_type_id', $this->entity->entity_type_id)->get();
+        foreach($attributes as $attribute) {
+            $this->attributes[$attribute->attribute_code] = $attribute;
+        }
+        
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function update($primaryKey, array $updates) {
+
+        // first update the static properties:
+        $staticUpdates = array_filter($updates, function($value, $key) use($this) {
+            return $this->attributes[$key]->backend_type === 'static';
+        }, ARRAY_FILTER_USE_BOTH);
+
+        $this->db->table($this->table['name'])->where($this->table['pk'], $primaryKey)->update($updates);
+
+        // now individually update any EAV tables using $attribute->backend_type to determine table name...
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function query() : \Illuminate\Database\Query\Builder {
+        $query = $this->db->table($this->table['name']);
+
+        $where = array_get($this->options, 'where', null);
+        if ($where) {
+            $query->whereRaw($where);
+        }
+
+        // add any required attributes to the query using joins...
+
+        return $query;
+    }
+}
+

--- a/src/Elgentos/Masquerade/Provider/Table/Magento2Eav.php
+++ b/src/Elgentos/Masquerade/Provider/Table/Magento2Eav.php
@@ -22,14 +22,24 @@ class Magento2Eav extends Simple
     public function setup()
     {
         // find all EAV attribues for this table:
-        $this->entity = $this->db->table('eav_entity_types')->where('entity_table', $this->table['name'])->first();
+        $this->entity = $this->db->table('eav_entity_type')->where('entity_table', $this->table['name'])->first();
         if (!$this->entity) {
             throw new \Exception("Table {$this->table['name']} is not associated with EAV entities");
         }
         $attributes = $this->db->table('eav_attribute')->where('entity_type_id', $this->entity->entity_type_id)->get();
         foreach ($attributes as $attribute) {
             $this->attributes[$attribute->attribute_code] = $attribute;
+            if ($attribute->is_unique && isset($this->table['columns']) && isset($this->table['columns'][$attribute->attribute_code])) {
+                $this->output->writeln(' - forcing ' . $attribute->attribute_code . ' to be unique');
+                $this->table['columns'][$attribute->attribute_code]['unique'] = true;
+            }
         }
+
+	// useful data in $this->attributes[$code]:
+        // ->attribute_id
+        // ->backend_type - gives us the table suffix
+        // ->is_unique - we use this to apply the 'unique' faker setting
+        // ->is_required - we don't use this, because if it's a required value then it'll already exist in the DB
         
         parent::setup();
     }
@@ -46,13 +56,37 @@ class Magento2Eav extends Simple
     {
 
         // first update the static properties:
-        $staticUpdates = array_filter($updates, function ($value, $key) {
-            return $this->attributes[$key]->backend_type === 'static';
+        $staticUpdates = array_filter($updates, function ($value, $code) {
+            return $this->_isInBaseTable($code);
         }, ARRAY_FILTER_USE_BOTH);
 
-        $this->db->table($this->table['name'])->where($this->table['pk'], $primaryKey)->update($updates);
+	// only update static values if there are any:
+        if (count($staticUpdates)) {
+            $this->db->table($this->table['name'])->where($this->table['pk'], $primaryKey)->update($staticUpdates);
+        }
 
-        // now individually update any EAV tables using $attribute->backend_type to determine table name...
+        // now individually update any EAV tables using $attribute->backend_type to determine table name:
+	// NOTE: for attributes with per-store values (eg. products) this will put the same value in for each store ID
+        foreach($updates as $code => $value) {
+            if ($this->_isInBaseTable($code)) {
+                continue;
+            }
+            // determine the table name for this attribute (we're ignoring eav_attribute->backend_table because nothing uses it)
+            $table = $this->table['name'] . '_' . $this->attributes[$code]->backend_type;
+            // we're assuming the entity ID field is 'entity_id' - could be overridden in eav_entity_type->entity_id_field but unlikely
+            // update anything for this entity ID
+            $this->db->table($table)
+		->where('entity_id', '=', $primaryKey)
+		->where('attribute_id', '=', $this->attributes[$code]->attribute_id)
+		->update([
+		    'value' => $value
+		]);
+        }
+    }
+
+    protected function _isInBaseTable($attributeCode)
+    {
+        return !isset($this->attributes[$attributeCode]) || $this->attributes[$attributeCode]->backend_type === 'static';
     }
 
     /**
@@ -74,7 +108,7 @@ class Magento2Eav extends Simple
                 continue;
             }
             $joinTable = $this->table['name'] . '_' . $attr->backend_type; // only for basic EAV, not things like tier_price
-            $query->leftJoin($joinTable, function ($join) use ($joinTable) {
+            $query->leftJoin($joinTable, function ($join) use ($joinTable, $attr) {
                 $join->on("{$this->table['name']}.{$this->table['pk']}", '=', "{$joinTable}.entity_id")
                     ->where("{$joinTable}.attribute_id", '=', $attr->attribute_id);
             });

--- a/src/Elgentos/Masquerade/Provider/Table/Magento2Eav.php
+++ b/src/Elgentos/Masquerade/Provider/Table/Magento2Eav.php
@@ -35,7 +35,7 @@ class Magento2Eav extends Simple
             }
         }
 
-	// useful data in $this->attributes[$code]:
+        // useful data in $this->attributes[$code]:
         // ->attribute_id
         // ->backend_type - gives us the table suffix
         // ->is_unique - we use this to apply the 'unique' faker setting
@@ -60,14 +60,14 @@ class Magento2Eav extends Simple
             return $this->_isInBaseTable($code);
         }, ARRAY_FILTER_USE_BOTH);
 
-	// only update static values if there are any:
+        // only update static values if there are any:
         if (count($staticUpdates)) {
             $this->db->table($this->table['name'])->where($this->table['pk'], $primaryKey)->update($staticUpdates);
         }
 
         // now individually update any EAV tables using $attribute->backend_type to determine table name:
-	// NOTE: for attributes with per-store values (eg. products) this will put the same value in for each store ID
-        foreach($updates as $code => $value) {
+        // NOTE: for attributes with per-store values (eg. products) this will put the same value in for each store ID
+        foreach ($updates as $code => $value) {
             if ($this->_isInBaseTable($code)) {
                 continue;
             }
@@ -76,11 +76,11 @@ class Magento2Eav extends Simple
             // we're assuming the entity ID field is 'entity_id' - could be overridden in eav_entity_type->entity_id_field but unlikely
             // update anything for this entity ID
             $this->db->table($table)
-		->where('entity_id', '=', $primaryKey)
-		->where('attribute_id', '=', $this->attributes[$code]->attribute_id)
-		->update([
-		    'value' => $value
-		]);
+                ->where('entity_id', '=', $primaryKey)
+                ->where('attribute_id', '=', $this->attributes[$code]->attribute_id)
+                ->update([
+                    'value' => $value
+                ]);
         }
     }
 
@@ -100,13 +100,10 @@ class Magento2Eav extends Simple
 
         // add any required attributes to the query using joins...
         foreach ($this->columns() as $columnName => $column) {
-            $attr = $this->attributes[$columnName] ?? null;
-            if (!$attr) {
+            if ($this->_isInBaseTable($columnName)) {
                 continue;
             }
-            if ($attr->backend_type === 'static') {
-                continue;
-            }
+            $attr = $this->attributes[$columnName];
             $joinTable = $this->table['name'] . '_' . $attr->backend_type; // only for basic EAV, not things like tier_price
             $query->leftJoin($joinTable, function ($join) use ($joinTable, $attr) {
                 $join->on("{$this->table['name']}.{$this->table['pk']}", '=', "{$joinTable}.entity_id")

--- a/src/Elgentos/Masquerade/Provider/Table/Magento2Eav.php
+++ b/src/Elgentos/Masquerade/Provider/Table/Magento2Eav.php
@@ -9,7 +9,8 @@ namespace Elgentos\Masquerade\Provider\Table;
  *
  */
 
-class Magento2Eav extends Simple {
+class Magento2Eav extends Simple
+{
 
     /**
      * @var array of eav_attribute records
@@ -26,24 +27,26 @@ class Magento2Eav extends Simple {
             throw new \Exception("Table {$this->table['name']} is not associated with EAV entities");
         }
         $attributes = $this->db->table('eav_attribute')->where('entity_type_id', $this->entity->entity_type_id)->get();
-        foreach($attributes as $attribute) {
+        foreach ($attributes as $attribute) {
             $this->attributes[$attribute->attribute_code] = $attribute;
         }
         
         parent::setup();
     }
 
-    protected function _columnExists($name) {
+    protected function _columnExists($name)
+    {
         return parent::_columnExists($name) || isset($this->attributes[$name]);
     }
 
     /**
      * @inheritdoc
      */
-    public function update($primaryKey, array $updates) {
+    public function update($primaryKey, array $updates)
+    {
 
         // first update the static properties:
-        $staticUpdates = array_filter($updates, function($value, $key) {
+        $staticUpdates = array_filter($updates, function ($value, $key) {
             return $this->attributes[$key]->backend_type === 'static';
         }, ARRAY_FILTER_USE_BOTH);
 
@@ -55,13 +58,14 @@ class Magento2Eav extends Simple {
     /**
      * @inheritdoc
      */
-    public function query() : \Illuminate\Database\Query\Builder {
+    public function query() : \Illuminate\Database\Query\Builder
+    {
         $query = parent::query();
 
         $selects = ["{$this->table['name']}.*"];
 
         // add any required attributes to the query using joins...
-        foreach($this->columns() as $columnName => $column) {
+        foreach ($this->columns() as $columnName => $column) {
             $attr = $this->attributes[$columnName] ?? null;
             if (!$attr) {
                 continue;
@@ -70,7 +74,7 @@ class Magento2Eav extends Simple {
                 continue;
             }
             $joinTable = $this->table['name'] . '_' . $attr->backend_type; // only for basic EAV, not things like tier_price
-            $query->leftJoin($joinTable, function($join) use($joinTable) {
+            $query->leftJoin($joinTable, function ($join) use ($joinTable) {
                 $join->on("{$this->table['name']}.{$this->table['pk']}", '=', "{$joinTable}.entity_id")
                     ->where("{$joinTable}.attribute_id", '=', $attr->attribute_id);
             });
@@ -82,4 +86,3 @@ class Magento2Eav extends Simple {
         return $query;
     }
 }
-

--- a/src/Elgentos/Masquerade/Provider/Table/Simple.php
+++ b/src/Elgentos/Masquerade/Provider/Table/Simple.php
@@ -126,6 +126,14 @@ class Simple extends Base
         return $this->table['columns'];
     }
 
+    /**
+     * @inheritdoc
+     */
+    public function count()
+    {
+        return $this->query()->count(); // works unless you're using groupBy in the query
+    }
+
     protected function _columnExists($name)
     {
         return $this->db->getSchemaBuilder()->hasColumn($this->table['name'], $name);

--- a/src/Elgentos/Masquerade/Provider/Table/Simple.php
+++ b/src/Elgentos/Masquerade/Provider/Table/Simple.php
@@ -28,7 +28,7 @@ use \Symfony\Component\Console\Output\OutputInterface;
  *
  * where: a string containing a custom 'where' clause - for example, you could exclude data required for unit tests
  * delete: boolean - if true, don't anonymise this table, just delete the records specified
- *     (if no 'where' clause is present, it will try and use the 'truncate' method for speed)
+ * truncate: boolean - if true, ignore 'where' and 'delete' and just truncate the table - ignores any foreign key constraints
  *
  */
 
@@ -66,13 +66,12 @@ class Simple extends Base
         $this->getPrimaryKey(); // verify it exists
         $this->orderBy = $this->primaryKey; // default, could be overridden by a subclass
 
-        if (array_get($this->options, 'delete', false)) {
+        if (array_get($this->options, 'truncate', false)) {
+            $this->output->writeln(' - removing all records, ignoring foreign keys');
+            $this->query()->truncate();
+        } elseif (array_get($this->options, 'delete', false)) {
             $this->output->writeln(' - removing the selected records');
-            if (array_get($this->options, 'where', null)) {
-                $this->query()->delete();
-            } else {
-                $this->query()->truncate();
-            }
+            $this->query()->delete();
         }
 
         // Null columns before run to avoid integrity constrains errors

--- a/src/Elgentos/Masquerade/Provider/Table/Simple.php
+++ b/src/Elgentos/Masquerade/Provider/Table/Simple.php
@@ -32,7 +32,8 @@ use \Symfony\Component\Console\Output\OutputInterface;
  *
  */
 
-class Simple extends Base {
+class Simple extends Base
+{
 
     /**
      * Do any setup or validation work here, eg. extracting details from the database for later use,
@@ -59,7 +60,7 @@ class Simple extends Base {
             if (!$this->_columnExists($columnName)) {
                 unset($this->table['columns'][$columnName]);
                 $this->output->writeln('Column ' . $columnName . ' in table ' . $this->table['name'] . ' does not exist; skip it.');
-            }    
+            }
         }
 
         if (array_get($this->options, 'delete', false)) {
@@ -94,15 +95,16 @@ class Simple extends Base {
     /**
      * @inheritdoc
      */
-    public function update($primaryKey, array $updates) {
-
+    public function update($primaryKey, array $updates)
+    {
         $this->db->table($this->table['name'])->where($this->table['pk'], $primaryKey)->update($updates);
     }
 
     /**
      * @inheritdoc
      */
-    public function query() : \Illuminate\Database\Query\Builder {
+    public function query() : \Illuminate\Database\Query\Builder
+    {
         $query = $this->db->table($this->table['name'])->orderBy($this->table['pk']);
 
         $where = array_get($this->options, 'where', null);
@@ -113,4 +115,3 @@ class Simple extends Base {
         return $query;
     }
 }
-

--- a/src/Elgentos/Masquerade/Provider/Table/Simple.php
+++ b/src/Elgentos/Masquerade/Provider/Table/Simple.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace \Elgentos\Masquerade\Provider\Table;
+
+use \Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * The default provider - for plain, regular database tables
+ *
+ * It has options for adding a 'where' clause and a custom query
+ *
+ * example config:
+ *
+ * group1:   # the group
+ *   table1:  # the entity name
+ *     provider: \Elgentos\Masquerade\Provider\Table\Simple # not needed because it's the default
+ *     columns:
+ *       cost_price:
+ *         ...your usual column formatting goes here...
+ *
+ * group1:
+ *   table1:
+ *     provider:
+ *       class: \Elgentos\Masquerade\Provider\Table\Simple
+ *       where: "email is not like '%unit-test-user.com'"
+ *
+ * Options:
+ *
+ * where: a string containing a custom 'where' clause - for example, you could exclude data required for unit tests
+ * delete: boolean - if true, don't anonymise this table, just delete the records specified
+ *     (if no 'where' clause is present, it will try and use the 'truncate' method for speed)
+ *
+ */
+
+class Simple extends Base {
+
+    /**
+     * Do any setup or validation work here, eg. extracting details from the database for later use,
+     * removing unused columns, etc
+     *
+     * @return void
+     */
+    public function setup()
+    {
+        if (array_get($this->options, 'delete', false)) {
+            if (array_get($this->options, 'where', null)) {
+                $this->query()->delete();
+            } else {
+                $this->query()->truncate();
+            }
+        }
+
+        // check the table exists:
+        if (!$this->db->getSchemaBuilder()->hasTable($this->table['name'])) {
+            throw new \Exception('Table ' . $this->table['name'] . ' does not exist.');
+        }
+
+        foreach ($this->table['columns'] as $columnName => $columnData) {
+            if (!$this->db->getSchemaBuilder()->hasColumn($this->table['name'], $columnName)) {
+                unset($this->table['columns'][$columnName]);
+                $this->output->writeln('Column ' . $columnName . ' in table ' . $this->table['name'] . ' does not exist; skip it.');
+            }    
+        }
+
+        // Null columns before run to avoid integrity constrains errors
+        foreach ($this->table['columns'] as $columnName => $columnData) {
+            if (array_get($columnData, 'nullColumnBeforeRun', false)) {
+                $this->query()->update([$columnName => null]);
+            }
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function columns()
+    {
+        return $this->table['columns'];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function update($primaryKey, array $updates) {
+
+        $this->db->table($this->table['name'])->where($this->table['pk'], $primaryKey)->update($updates);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function query() : \Illuminate\Database\Query\Builder {
+        $query = $this->db->table($this->table['name']);
+
+        $where = array_get($this->options, 'where', null);
+        if ($where) {
+            $query->whereRaw($where);
+        }
+
+        return $query;
+    }
+}
+

--- a/src/Elgentos/Masquerade/Provider/Table/Simple.php
+++ b/src/Elgentos/Masquerade/Provider/Table/Simple.php
@@ -66,7 +66,7 @@ class Simple extends Base
         $this->orderBy = $this->primaryKey; // default, could be overridden by a subclass
 
         if (Arr::get($this->options, 'delete', false)) {
-            if($this->input->getOption('with-integrity') || Arr::get($this->options, 'where', null)) {
+            if ($this->input->getOption('with-integrity') || Arr::get($this->options, 'where', null)) {
                 $this->output->writeln(' - removing the selected records');
                 $this->query()->delete();
             } else {

--- a/src/config/magento2-without-orders/admin.yaml
+++ b/src/config/magento2-without-orders/admin.yaml
@@ -1,0 +1,18 @@
+admin:
+  admin_user:
+    pk: user_id
+    columns:
+      firstname:
+        formatter: firstName
+      lastname:
+        formatter: lastName
+      email:
+        formatter: email
+        nullColumnBeforeRun: true
+        unique: true
+      username:
+        formatter: firstName
+        nullColumnBeforeRun: true
+        unique: true
+      password:
+        formatter: password

--- a/src/config/magento2-without-orders/creditmemo.yaml
+++ b/src/config/magento2-without-orders/creditmemo.yaml
@@ -1,0 +1,29 @@
+creditmemo:
+  sales_creditmemo:
+    columns:
+      customer_note:
+        formatter: sentence
+      transaction_id:
+        formatter:
+          name: randomNumber
+          nbDigits: 8
+
+  sales_creditmemo_comment:
+    columns:
+      comment:
+        formatter: sentence
+
+  sales_creditmemo_grid:
+    columns:
+      customer_email:
+        formatter: email
+        unique: true
+        nullColumnBeforeRun: true
+      customer_name:
+        formatter: name
+      billing_name:
+        formatter: name
+      shipping_address:
+        formatter: address
+      billing_address:
+        formatter: address

--- a/src/config/magento2-without-orders/customer.yaml
+++ b/src/config/magento2-without-orders/customer.yaml
@@ -1,0 +1,82 @@
+customer:
+  customer_entity:
+    columns:
+      email:
+        formatter: email
+        unique: true
+        nullColumnBeforeRun: true
+      prefix:
+        formatter:
+          name: fixed
+          value:
+      firstname:
+        formatter:
+          name: firstName
+      middlename:
+        formatter:
+          name: fixed
+          value:
+      lastname:
+        formatter: lastName
+      suffix:
+        formatter:
+          name: fixed
+          value:
+
+  customer_address_entity:
+    columns:
+      firstname:
+        formatter: firstName
+      lastname:
+        formatter: lastName
+      company:
+        formatter: company
+        optional: true
+      street:
+        formatter: streetAddress
+      city:
+        formatter: city
+      postcode:
+        formatter: postcode
+      telephone:
+        formatter: phoneNumber
+      fax:
+        formatter: phoneNumber
+        optional: true
+
+  customer_grid_flat:
+    columns:
+      name:
+        formatter: name
+      email:
+        formatter: email
+        unique: true
+        nullColumnBeforeRun: true
+      dob:
+        formatter: dateTimeThisCentury
+        optional: true
+      billing_full:
+        formatter: address
+      shipping_full:
+        formatter: address
+      billing_firstname:
+        formatter: firstName
+      billing_lastname:
+        formatter: lastName
+      billing_telephone:
+        formatter: phoneNumber
+      billing_postcode:
+        formatter: postcode
+      billing_street:
+        formatter: streetAddress
+      billing_city:
+        formatter: city
+      billing_fax:
+        formatter: phoneNumber
+        optional: true
+      billing_vat_id:
+        formatter: vat
+        optional: true
+      billing_company:
+        formatter: company
+        optional: true

--- a/src/config/magento2-without-orders/ee_rma.yaml
+++ b/src/config/magento2-without-orders/ee_rma.yaml
@@ -1,0 +1,5 @@
+ee_rma:
+  magento_rma_grid:
+    columns:
+      customer_name:
+        formatter: name

--- a/src/config/magento2-without-orders/ee_sales_archive.yaml
+++ b/src/config/magento2-without-orders/ee_sales_archive.yaml
@@ -1,0 +1,58 @@
+ee_sales_archive:
+  magento_sales_creditmemo_grid_archive:
+    columns:
+      customer_name:
+        formatter: name
+      billing_name:
+        formatter: name
+      billing_address:
+        formatter: address
+      shipping_address:
+        formatter: address
+      customer_email:
+        formatter: email
+
+  magento_sales_invoice_grid_archive:
+    columns:
+      customer_name:
+        formatter: name
+      billing_name:
+        formatter: name
+      billing_address:
+        formatter: address
+      shipping_address:
+        formatter: address
+      customer_email:
+        formatter: email
+
+  magento_sales_order_grid_archive:
+    columns:
+      customer_name:
+        formatter: name
+      billing_name:
+        formatter: name
+      shipping_name:
+        formatter: name
+      billing_address:
+        formatter: address
+      shipping_address:
+        formatter: address
+      customer_email:
+        formatter: email
+      postcode:
+        formatter: postcode
+
+  magento_sales_shipment_grid_archive:
+    columns:
+      customer_name:
+        formatter: name
+      billing_name:
+        formatter: name
+      shipping_name:
+        formatter: name
+      billing_address:
+        formatter: address
+      shipping_address:
+        formatter: address
+      customer_email:
+        formatter: email

--- a/src/config/magento2-without-orders/email.yaml
+++ b/src/config/magento2-without-orders/email.yaml
@@ -1,0 +1,18 @@
+email:
+  email_contact:
+    pk: email_contact_id
+    columns:
+      email:
+        formatter: email
+
+  email_automation:
+    pk: id
+    columns:
+      email:
+        formatter: email
+
+  email_campaign:
+    pk: id
+    columns:
+      email:
+        formatter: email

--- a/src/config/magento2-without-orders/invoice.yaml
+++ b/src/config/magento2-without-orders/invoice.yaml
@@ -1,0 +1,27 @@
+invoice:
+  sales_invoice:
+    columns:
+      customer_note:
+        formatter: sentence
+        optional: true
+
+  sales_invoice_comment:
+    columns:
+      comment:
+        formatter: sentence
+        optional: true
+
+  sales_invoice_grid:
+    columns:
+      customer_email:
+        formatter: email
+        unique: true
+        nullColumnBeforeRun: true
+      customer_name:
+        formatter: name
+      billing_name:
+        formatter: name
+      shipping_address:
+        formatter: address
+      billing_address:
+        formatter: address

--- a/src/config/magento2-without-orders/newsletter.yaml
+++ b/src/config/magento2-without-orders/newsletter.yaml
@@ -1,0 +1,8 @@
+newsletter:
+  newsletter_subscriber:
+    pk: subscriber_id
+    columns:
+      subscriber_email:
+        formatter: email
+        unique: true
+        nullColumnBeforeRun: true

--- a/src/config/magento2-without-orders/order.yaml
+++ b/src/config/magento2-without-orders/order.yaml
@@ -1,0 +1,12 @@
+order:
+  sales_order:
+    provider:
+      delete: true
+
+  sales_order_grid:
+    provider:
+      delete: true
+
+  sales_order_address:
+    provider:
+      delete: true

--- a/src/config/magento2-without-orders/quote.yaml
+++ b/src/config/magento2-without-orders/quote.yaml
@@ -1,0 +1,48 @@
+quote:
+  quote:
+    columns:
+      customer_email:
+        formatter: email
+        unique: true
+        nullColumnBeforeRun: true
+      customer_firstname:
+        formatter: firstName
+      customer_lastname:
+        formatter: lastName
+      customer_dob:
+        formatter: dateTimeThisCentury
+        optional: true
+      customer_taxvat:
+        formatter: vat
+        optional: true
+      remote_ip:
+        formatter: ipv4
+
+  quote_address:
+    pk: address_id
+    columns:
+      email:
+        formatter: email
+        unique: true
+        nullColumnBeforeRun: true
+      firstname:
+        formatter: firstName
+      lastname:
+        formatter: lastName
+      company:
+        formatter: company
+        optional: true
+      street:
+        formatter: streetAddress
+      city:
+        formatter: city
+      postcode:
+        formatter: postcode
+      telephone:
+        formatter: phoneNumber
+      fax:
+        formatter: phoneNumber
+        optional: true
+      vat_id:
+        formatter: vat
+        optional: true

--- a/src/config/magento2-without-orders/rating.yaml
+++ b/src/config/magento2-without-orders/rating.yaml
@@ -1,0 +1,8 @@
+rating:
+  rating_option_vote:
+    pk: vote_id
+    columns:
+      remote_ip:
+        formatter: ipv4
+      remote_ip_long:
+        formatter: randomNumber

--- a/src/config/magento2-without-orders/review.yaml
+++ b/src/config/magento2-without-orders/review.yaml
@@ -1,0 +1,10 @@
+review:
+  review_detail:
+    pk: detail_id
+    columns:
+      nickname:
+        formatter: firstName
+      title:
+        formatter: sentence
+      detail:
+        formatter: paragraph

--- a/src/config/magento2-without-orders/shipment.yaml
+++ b/src/config/magento2-without-orders/shipment.yaml
@@ -1,0 +1,29 @@
+shipment:
+  sales_shipment:
+    columns:
+      customer_note:
+        formatter: sentence
+        optional: true
+
+  sales_shipment_comment:
+    columns:
+      comment:
+        formatter: sentence
+        optional: true
+
+  sales_shipment_grid:
+    columns:
+      customer_email:
+        formatter: email
+        unique: true
+        nullColumnBeforeRun: true
+      customer_name:
+        formatter: name
+      shipping_name:
+        formatter: name
+      billing_name:
+        formatter: name
+      shipping_address:
+        formatter: address
+      billing_address:
+        formatter: address

--- a/src/config/sample/delete_examples.yaml
+++ b/src/config/sample/delete_examples.yaml
@@ -1,0 +1,11 @@
+delete_examples:
+  table_to_fully_truncate:
+    provider:
+      delete: true # without the 'where', this will automatically use 'truncate' rather than 'delete', for speed
+  table_to_partially_delete:
+    provider:
+      delete: true
+      where: " `is_unit_testing_data` = 0 " # deletes the specified records only
+      # no need to provide columns here, because we're deleting rather than anonymizing
+
+

--- a/src/config/sample/delete_examples.yaml
+++ b/src/config/sample/delete_examples.yaml
@@ -1,7 +1,10 @@
 delete_examples:
   table_to_fully_truncate:
     provider:
-      delete: true # without the 'where', this will automatically use 'truncate' rather than 'delete', for speed
+      truncate: true # ignores key constraints, so use it when the data is large and delete would be slow
+  table_to_fully_delete:
+    provider:
+      delete: true
   table_to_partially_delete:
     provider:
       delete: true

--- a/src/config/sample/magento_eav.yaml
+++ b/src/config/sample/magento_eav.yaml
@@ -1,0 +1,24 @@
+eav_example:
+  catalog_product_entity: # specify the base table for the entity
+    pk: entity_id
+    provider: \Elgentos\Masquerade\Provider\Table\Magento2Eav
+    columns:
+      # custom attribute, could be any type
+      my_custom_attribute:
+        formatter:
+          name: lexify
+          value: "?????"
+      # it also does fields in the main table:
+      sku:
+        formatter:
+          name: bothify
+          value: "???####"
+        unique: true
+
+  amasty_order_attribute_entity: # even handle entities provided by 3rd party modules
+    pk: entity_id
+    provider: \Elgentos\Masquerade\Provider\Table\Magento2Eav
+    columns:
+      my_custom_order_attribute:
+        formatter: email
+

--- a/src/config/sample/partial_anonymize.yaml
+++ b/src/config/sample/partial_anonymize.yaml
@@ -1,0 +1,11 @@
+partial_anonymize:
+  table_with_test_users:
+    provider: # the 'class' below isn't needed because 'Simple' is the default
+      class: \Elgentos\Masquerade\Provider\Table\Simple
+      where: " email not like '%@example.com' " # leave the example.com users alone, they're for our unit tests
+    columns:
+      email:
+        formatter: email
+      name:
+        formatter: name
+


### PR DESCRIPTION
Working with Magento2 EAV.

This adds 'table providers' - so new types of complex table can be added either by the end user or within the package.

See `src/config/sample/magento_eav.yaml` for example config.

It also adds new 'where' and 'delete' options at table level, so you can truncate tables you don't need or only affect certain data - for example, to leave data alone which is used by unit tests.

This opens the door for adding table types for Wordpress and Drupal, which have their own linked-table systems - eg. in a Wordpress table provider, we'd be able to specify 'postmeta' fields to be anonymised, simply by adding a new class.

See the updates in README.md for more info and see examples in `src/config/sample`. 