### PR TITLE
fixed build.sh to work with the default box installer process

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,8 @@
+mkdir -p dist
 if [ -f ../box/box.phar ]; then
     php -d phar.readonly=off ../box/box.phar build -v
+elif [ -f ./box.phar ]; then
+    php -d phar.readonly=off ./box.phar build -v
 else
-    php -d phar.readyonly=off box build -v
+    php -d phar.readonly=off box build -v
 fi


### PR DESCRIPTION
I'm not sure if this is appropriate for the main repo but thought I'd send it anyway:

When I followed the build instructions in README, I got ./box.phar and no 'dist' directory, so this makes the build process work when following the steps in the README.