### PR TITLE
Provide an extra config folder on the command line

### DIFF
--- a/src/Elgentos/Masquerade/Console/GroupsCommand.php
+++ b/src/Elgentos/Masquerade/Console/GroupsCommand.php
@@ -40,6 +40,7 @@ class GroupsCommand extends Command
         $this
             ->setName($this->name)
             ->setDescription($this->description)
+            ->addOption('config', null, InputOption::VALUE_OPTIONAL, 'Extra config directory for config.yaml or platform configs')
             ->addOption('platform', null, InputOption::VALUE_REQUIRED);
     }
 
@@ -83,7 +84,7 @@ class GroupsCommand extends Command
      */
     private function setup()
     {
-        $this->configHelper = new Config();
+        $this->configHelper = new Config(['path' => $this->input->getOption('config')]);
         $databaseConfig = $this->configHelper->readConfigFile();
 
         $this->platformName = $this->input->getOption('platform') ?? $databaseConfig['platform'];

--- a/src/Elgentos/Masquerade/Console/GroupsCommand.php
+++ b/src/Elgentos/Masquerade/Console/GroupsCommand.php
@@ -40,7 +40,7 @@ class GroupsCommand extends Command
         $this
             ->setName($this->name)
             ->setDescription($this->description)
-            ->addOption('config', null, InputOption::VALUE_OPTIONAL, 'Extra config directory for config.yaml or platform configs')
+            ->addOption('config', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'One or more extra config directories for config.yaml or platform configs')
             ->addOption('platform', null, InputOption::VALUE_REQUIRED);
     }
 
@@ -84,7 +84,7 @@ class GroupsCommand extends Command
      */
     private function setup()
     {
-        $this->configHelper = new Config(['path' => $this->input->getOption('config')]);
+        $this->configHelper = new Config($this->input->getOptions());
         $databaseConfig = $this->configHelper->readConfigFile();
 
         $this->platformName = $this->input->getOption('platform') ?? $databaseConfig['platform'];

--- a/src/Elgentos/Masquerade/Console/IdentifyCommand.php
+++ b/src/Elgentos/Masquerade/Console/IdentifyCommand.php
@@ -58,6 +58,7 @@ class IdentifyCommand extends Command
         $this
             ->setName($this->name)
             ->setDescription($this->description)
+            ->addOption('config', null, InputOption::VALUE_OPTIONAL, 'Extra config directory for config.yaml or platform configs')
             ->addOption('platform', null, InputOption::VALUE_OPTIONAL)
             ->addOption('driver', null, InputOption::VALUE_OPTIONAL, 'Database driver [mysql]')
             ->addOption('database', null, InputOption::VALUE_OPTIONAL)
@@ -128,7 +129,7 @@ class IdentifyCommand extends Command
      */
     private function setup()
     {
-        $this->configHelper = new Config();
+        $this->configHelper = new Config(['path' => $this->input->getOption('config')]);
         $databaseConfig = $this->configHelper->readConfigFile();
 
         $this->platformName = $this->input->getOption('platform') ?? $databaseConfig['platform'];

--- a/src/Elgentos/Masquerade/Console/IdentifyCommand.php
+++ b/src/Elgentos/Masquerade/Console/IdentifyCommand.php
@@ -58,7 +58,7 @@ class IdentifyCommand extends Command
         $this
             ->setName($this->name)
             ->setDescription($this->description)
-            ->addOption('config', null, InputOption::VALUE_OPTIONAL, 'Extra config directory for config.yaml or platform configs')
+            ->addOption('config', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'One or more extra config directories for config.yaml or platform configs')
             ->addOption('platform', null, InputOption::VALUE_OPTIONAL)
             ->addOption('driver', null, InputOption::VALUE_OPTIONAL, 'Database driver [mysql]')
             ->addOption('database', null, InputOption::VALUE_OPTIONAL)
@@ -129,7 +129,7 @@ class IdentifyCommand extends Command
      */
     private function setup()
     {
-        $this->configHelper = new Config(['path' => $this->input->getOption('config')]);
+        $this->configHelper = new Config($this->input->getOptions());
         $databaseConfig = $this->configHelper->readConfigFile();
 
         $this->platformName = $this->input->getOption('platform') ?? $databaseConfig['platform'];

--- a/src/Elgentos/Masquerade/Console/RunCommand.php
+++ b/src/Elgentos/Masquerade/Console/RunCommand.php
@@ -76,6 +76,7 @@ class RunCommand extends Command
         $this
             ->setName($this->name)
             ->setDescription($this->description)
+            ->addOption('config', null, InputOption::VALUE_OPTIONAL, 'Extra config directory for config.yaml or platform configs')
             ->addOption('platform', null, InputOption::VALUE_OPTIONAL)
             ->addOption('driver', null, InputOption::VALUE_OPTIONAL, 'Database driver [mysql]')
             ->addOption('database', null, InputOption::VALUE_OPTIONAL)
@@ -203,7 +204,7 @@ class RunCommand extends Command
      */
     private function setup()
     {
-        $this->configHelper = new Config();
+        $this->configHelper = new Config(['path' => $this->input->getOption('config')]);
 
         $databaseConfig = $this->configHelper->readConfigFile();
 

--- a/src/Elgentos/Masquerade/Console/RunCommand.php
+++ b/src/Elgentos/Masquerade/Console/RunCommand.php
@@ -76,7 +76,7 @@ class RunCommand extends Command
         $this
             ->setName($this->name)
             ->setDescription($this->description)
-            ->addOption('config', null, InputOption::VALUE_OPTIONAL, 'Extra config directory for config.yaml or platform configs')
+            ->addOption('config', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'One or more extra config directories for config.yaml or platform configs')
             ->addOption('platform', null, InputOption::VALUE_OPTIONAL)
             ->addOption('driver', null, InputOption::VALUE_OPTIONAL, 'Database driver [mysql]')
             ->addOption('database', null, InputOption::VALUE_OPTIONAL)
@@ -204,7 +204,7 @@ class RunCommand extends Command
      */
     private function setup()
     {
-        $this->configHelper = new Config(['path' => $this->input->getOption('config')]);
+        $this->configHelper = new Config($this->input->getOptions());
 
         $databaseConfig = $this->configHelper->readConfigFile();
 

--- a/src/Elgentos/Masquerade/Helper/Config.php
+++ b/src/Elgentos/Masquerade/Helper/Config.php
@@ -17,6 +17,13 @@ class Config
         'config',
     ];
 
+    public function __construct($options = [])
+    {
+        if ($options['path']) {
+            $this->configDirs[] = $options['path'];
+        }
+    }
+
     /**
      * @param string $rootDir
      * @param string $file

--- a/src/Elgentos/Masquerade/Helper/Config.php
+++ b/src/Elgentos/Masquerade/Helper/Config.php
@@ -19,8 +19,10 @@ class Config
 
     public function __construct($options = [])
     {
-        if ($options['path']) {
-            $this->configDirs[] = $options['path'];
+        if ($options['config'] ?? null) {
+            foreach ($options['config'] as $dir) {
+                $this->configDirs[] = $dir;
+            }
         }
     }
 


### PR DESCRIPTION
(updated to allow multiple --config options)

I want to run masquerade from the base directory of a Magento project during CI/CD, with custom config, but do not want a folder there called "config".

Rather than adding more default folders, I've added a command line option to specify extra folders, eg.

`masquerade.phar run --config my/global/confi --config my/local/config --platform xxxxx ....`

The config helper constructor gets passed all the command line options.