### PR TITLE
Remove table alias

### DIFF
--- a/src/Elgentos/Masquerade/DataProcessor/TableService.php
+++ b/src/Elgentos/Masquerade/DataProcessor/TableService.php
@@ -52,7 +52,7 @@ class TableService
      */
     public function query(): Builder
     {
-        return $this->database->query()->from(sprintf("%s as main", $this->tableName));
+        return $this->database->query()->from($this->tableName);
     }
 
     /**


### PR DESCRIPTION
Fixes #70 - the alias breaks the delete option.

I did a test without the table alias and It didn't break anything. I also searched the source code for the alias and I couldn't find anything.