### PR TITLE
Fix for Mysql 8

### DIFF
--- a/src/Elgentos/Masquerade/DataProcessor/TableServiceFactory.php
+++ b/src/Elgentos/Masquerade/DataProcessor/TableServiceFactory.php
@@ -50,7 +50,7 @@ class TableServiceFactory
     {
         $query = $this->database->query()
             ->from('information_schema.columns')
-            ->select(['column_name', 'column_key'])
+            ->select(['column_name as column_name', 'column_key as column_key'])
             ->where('table_name', '=', $this->database->getTablePrefix() . $tableName)
             ->whereRaw('table_schema = DATABASE()');
 


### PR DESCRIPTION
Masquerade is currently not working with Mysql 8. It will result in the following error:
```
PHP Notice:  Undefined property: stdClass::$column_key in vendor/illuminate/database/Query/Builder.php on line 2367
Notice: Undefined property: stdClass::$column_key in vendor/illuminate/database/Query/Builder.php on line 2367
ERROR: Table xyz does not have primary key configured, which makes impossible table anonymization.
```

I found this [Laravel  PR](https://github.com/laravel/framework/pull/21037/files) that fixed this exact issue, so I applied it to Masquerade. 

The difference is that in mysql 5.7 `select column_name from information_schema.columns;` will return:
```
mysql> select column_name from information_schema.columns;
+----------------------------------------------+
| column_name                                  |
+----------------------------------------------+
| ...                           |
```

And in mysql 8 it returns:
```
mysql> select column_name from information_schema.columns;
+----------------------------------------------+
| COLUMN_NAME                                  |
+----------------------------------------------+
| ...                           |
```

Adding an alias for `column_name` and `column_key` will make sure that the column name will remain lowercase in Mysql 8.