### PR TITLE
Work with composer global require

### DIFF
--- a/bin/masquerade
+++ b/bin/masquerade
@@ -1,7 +1,11 @@
 #!/usr/bin/env php
 <?php
 
-require_once __DIR__.'/../vendor/autoload.php';
+if (file_exists(__DIR__.'/../../../autoload.php')) {
+    require_once __DIR__.'/../../../autoload.php';
+} else {
+    require_once __DIR__.'/../vendor/autoload.php';
+}
 
 use Elgentos\Masquerade\Console\GroupsCommand;
 use Elgentos\Masquerade\Console\RunCommand;


### PR DESCRIPTION
Hello,
This project is on packagist, it's very usefull to use the composer global require instead of using the .phar installation.
But with the global require the autoloadfile.php is not at the same place.
With this code the bin file will work with phar and composer require