### PR TITLE
Change MySQL GLOBAL to SESSION mode

### DIFF
--- a/src/Elgentos/Masquerade/Console/RunCommand.php
+++ b/src/Elgentos/Masquerade/Console/RunCommand.php
@@ -327,7 +327,7 @@ class RunCommand extends Command
             $this->db->statement('SET FOREIGN_KEY_CHECKS=0');
         }
 
-        $this->db->statement("SET GLOBAL sql_mode=''");
+        $this->db->statement("SET SESSION sql_mode=''");
 
         $this->tableServiceFactory = new TableServiceFactory($this->db);
 


### PR DESCRIPTION
Using `GLOBAL` requires certain privileges, and affects the whole Database server.

Instead, we should use `SESSION` to change the sql_mode, so that we don't affect any other client, and can work with non-privileged users.

(Using it like this already in a live project)