### PR TITLE
fix -vv and higher verbosity level

### DIFF
--- a/src/Elgentos/Masquerade/Console/SymfonyOutput.php
+++ b/src/Elgentos/Masquerade/Console/SymfonyOutput.php
@@ -122,5 +122,9 @@ class SymfonyOutput implements Output
             $formatName,
             ProgressBar::getFormatDefinition($originalFormat) . " %message%"
         );
+        ProgressBar::setFormatDefinition(
+            $formatName . "_nomax",
+            ProgressBar::getFormatDefinition($originalFormat . "_nomax") . " %message%"
+        );
     }
 }


### PR DESCRIPTION
Must add a format definition for $formatName . "_nomax".
This also addresses the case where the number of records to process is
0 because the where: clause does not match any records.

Fixes elgentos/masquerade#83.