### PR TITLE
Added a verification to ensure the group tables are not empty

### DIFF
--- a/src/Elgentos/Masquerade/Console/RunCommand.php
+++ b/src/Elgentos/Masquerade/Console/RunCommand.php
@@ -125,7 +125,7 @@ class RunCommand extends Command
         $startTime = new \DateTime();
 
         foreach ($this->config as $groupName => $tables) {
-            if (!empty($this->group) && !in_array($groupName, $this->group)) {
+            if ((!empty($this->group) && !in_array($groupName, $this->group)) || empty($tables)) {
                 continue;
             }
             foreach ($tables as $tableName => $table) {


### PR DESCRIPTION
When trying to skip a configuration file without tables as stated in the docuemention https://github.com/elgentos/masquerade#customization. A warning is triggered 

```
PHP Warning:  Invalid argument supplied for foreach() in masquerade.phar/src/Elgentos/Masquerade/Console/RunCommand.php on line 131
```

To prevent this and solve the issue https://github.com/elgentos/masquerade/issues/109, I added a verification to ensure tables is not empty